### PR TITLE
add support for Space Exploration

### DIFF
--- a/locale/en/space_exploration.cfg
+++ b/locale/en/space_exploration.cfg
@@ -1,0 +1,23 @@
+[technology-name]
+hps__ml-se-space-miniloader=Space miniloader
+hps__ml-se-deep-space-miniloader=Deep space miniloader
+
+[technology-description]
+hps__ml-se-space-miniloader=A sticky miniloader designed to prevent items from flying into space.
+hps__ml-se-deep-space-miniloader=Extremely fast miniloader that can be used in space.
+
+[entity-name]
+hps__ml-se-space-miniloader=Space miniloader
+hps__ml-se-deep-space-miniloader=Deep space miniloader
+
+[entity-description]
+hps__ml-se-space-miniloader=A sticky miniloader designed to prevent items from flying into space.
+hps__ml-se-deep-space-miniloader=Extremely fast miniloader that can be used in space.
+
+[item-name]
+hps__ml-se-space-miniloader=Space miniloader
+hps__ml-se-deep-space-miniloader=Deep space miniloader
+
+[item-description]
+hps__ml-se-space-miniloader=A sticky miniloader designed to prevent items from flying into space.
+hps__ml-se-deep-space-miniloader=Extremely fast miniloader that can be used in space.

--- a/prototypes/templates.lua
+++ b/prototypes/templates.lua
@@ -15,6 +15,7 @@ local supported_mods = {
     ['Krastorio2'] = 'krastorio',
     ['boblogistics'] = 'bob',
     ['Load-Furn-2-SpaceAgeFix'] = 'adv_furnace_2',
+    ['space-exploration'] = 'space_exploration',
 }
 
 local game_mode = {}
@@ -54,6 +55,10 @@ local function check_adv_furnace_2()
     -- that thing is a hot mess...
     local logistics_enabled = settings.startup['logist'] and settings.startup['logist'].value or false
     return game_mode.adv_furnace_2 and logistics_enabled
+end
+
+local function check_space_exploration()
+    return game_mode.space_exploration
 end
 
 local function energy_void()
@@ -818,6 +823,90 @@ template.loaders = {
                 },
             }
         end,
+    },
+
+    -- =================================================
+    -- == Space Exploration
+    -- =================================================
+
+    ['se-space'] = {
+        condition = check_space_exploration,
+        data = function(dash_prefix)
+            return {
+                order = 'd[d]-a',
+                subgroup = 'belt',
+                stack_size = 50,
+                tint = { r = 240 / 255, g = 240 / 255, b = 240 / 255, a = 125 / 255 },
+                speed = data.raw['transport-belt'][dash_prefix..'transport-belt'].speed,
+                corpse_gfx = 'express',
+                ingredients = function()
+                    return select_data {
+                        space_exploration = {
+                            { type = "item" , name = dash_prefix..'transport-belt',   amount = 1 },
+                            { type = "item" , name = dash_prefix..'underground-belt', amount = 1 },
+                            { type = "item" , name = 'bulk-inserter',                 amount = 2 },
+                        },
+                    }
+                end,
+                prerequisites = function()
+                    return select_data {
+                        space_exploration = { 'se-space-belt', },
+                    }
+                end,
+                speed_config = {
+                    items_per_second = 45,
+                    rotation_speed = 0.125,
+                    inserter_pairs = 1,
+                    stack_size_bonus = 1,
+                }
+            }
+        end,
+    },
+
+    ['se-deep-space'] = {
+        condition = check_space_exploration,
+        data = function (dash_prefix)
+            local previous = 'se-space'
+            local color = '-black'
+
+            return {
+                order = 'd[d]-b',
+                subgroup = 'belt',
+                stack_size = 50,
+                tint = { r = 25 / 255, g = 25 / 255, b = 25 / 255, a = 200 / 255 },
+                speed = data.raw['transport-belt'][dash_prefix .. 'transport-belt'..color].speed,
+                upgrade_from = const:name_from_prefix(previous),
+                corpse_gfx = 'express',
+
+                ingredients = function()
+                    return select_data {
+                        space_exploration = {
+                            { type = "item" , name = const:name_from_prefix(previous),        amount = 2 },
+                            { type = "item" , name = dash_prefix..'underground-belt'..color,  amount = 1 },
+                            { type = "item" , name = 'se-nanomaterial',                       amount = 2 },
+                        },
+                    }
+                end,
+                prerequisites = function()
+                    return select_data {
+                        space_exploration = { 'se-deep-space-transport-belt', const:name_from_prefix(previous) },
+                    }
+                end,
+                belt_color_selector = function(loader)
+                    loader.belt_animation_set = util.copy(
+                        assert(
+                            data.raw['underground-belt'][dash_prefix..'underground-belt'..color].belt_animation_set
+                        )
+                    )
+                end,
+                speed_config = {
+                    items_per_second = 90,
+                    rotation_speed = 0.25,
+                    inserter_pairs = 1,
+                    stack_size_bonus = 3,
+                }
+            }
+        end
     },
 }
 


### PR DESCRIPTION
https://github.com/hgschmie/factorio-miniloader-redux/issues/28

Adds templates `se-space` and `se-deep-space`. Support for surfaces are in the next PR (defined in `this.othermods`).

<img width="773" height="608" alt="image" src="https://github.com/user-attachments/assets/987f079f-513c-4fea-992d-2ed12d9a0aa8" />

- Space and Deep space miniloaders use the `express` corpse, matching what SE uses for normal space and deep space belt corpses.
- Space miniloaders are not an upgrade from express belts since express belts are unlocked after space science, and do not have a previous tier since this is the first belt you can place in space.
- Deep space miniloaders use black as the default colour, which matches Krastorio 2's deep space loader in SE's compatibility support. This means that I have to concatenate `'-black'` to the end of some variables, and define a `belt_color_selector` as well.
- Deep space miniloaders use the speed config outlined in the table in `ADD_NEW_LOADERS.md`
- Tooltips and electricity usages are below

<img width="494" height="427" alt="image" src="https://github.com/user-attachments/assets/d16c4794-ccbd-4e19-9f7b-b18541bbf90f" />

<img width="490" height="483" alt="image" src="https://github.com/user-attachments/assets/c6dba533-4647-448b-8079-9a03b6401454" />
