### PR TITLE
add support for space tiles for Space Exploration

### DIFF
--- a/lib/other-mods/space-exploration.lua
+++ b/lib/other-mods/space-exploration.lua
@@ -1,0 +1,30 @@
+local const = require('lib.constants')
+
+local SpaceExplorationSupport = {}
+
+-- Support for space surface in Space Exploration. Only space and deep space miniloaders can be placed in space.
+--
+-- This is a hacky solution but it's the best I've got. 
+-- SE provides the `se_allow_in_space` property in a prototype that allows 
+-- entities (that would otherwise normally be blocked) to be placed in space.
+-- However miniloaders aren't blocked from being placed in space since they are
+-- actually inserters in disguise.
+
+SpaceExplorationSupport.data_updates = function()
+    for _, prototype in pairs(data.raw['inserter']) do
+        if prototype.name:sub(1, #const.prefix) == const.prefix then
+            if prototype.name:find('se-space', 1, true) ~= nil
+                or prototype.name:find('se-deep-space', 1, true) ~= nil
+            then
+                -- ignore
+            else
+                -- Hacky... 
+                if prototype.collision_mask then
+                    prototype.collision_mask.layers['space_tile'] = true
+                end
+            end
+        end
+    end
+end
+
+return SpaceExplorationSupport

--- a/lib/this.lua
+++ b/lib/this.lua
@@ -12,6 +12,7 @@ This = {
     other_mods = {
         ['PickerDollies'] = 'picker-dollies',
         ['even-pickier-dollies'] = 'picker-dollies',
+        ['space-exploration'] = 'space-exploration',
     },
 }
 


### PR DESCRIPTION
Continues PR https://github.com/hgschmie/factorio-miniloader-redux/pull/29 and finishes issue https://github.com/hgschmie/factorio-miniloader-redux/issues/28.

- Adds support for space surfaces when Space Exploration is enabled so that only `se-space` and `se-deep-space` miniloaders can be placed in space.

<img width="701" height="658" alt="image" src="https://github.com/user-attachments/assets/3ae5f23a-2c7c-4468-b1d7-3e855eb41077" />


This is a hacky solution but it's the best I've got. SE provides the `se_allow_in_space` property in a prototype that allows 
entities (that would otherwise normally be blocked) to be placed in space. However miniloaders aren't blocked from being placed in space since they are inserters. 

So I enabled the `space_tile` collision mask for inserter prototypes that start with the prefix `hps__ml-` and does not contain `se-space` or `se-deep-space`. This `space_tile` collision mask is created in `space-exploration/data.lua:34`:

```lua
-- data.lua
function se_make_collision_layer(name)
  if not data.raw["collision-layer"][name] then
    data:extend{{type = "collision-layer", name = name}}
  end
  return name
end

...

space_collision_layer = se_make_collision_layer("space_tile")
```

There are only a few examples in the SE source code that does this, and I followed this example in `space-exploration/prototypes/phase-1/combined/rail.lua:29`: 

```lua
local vanilla_rails_mask = table.deepcopy(collision_mask_util.get_mask(vanilla_rails[1]))
local space_rails_mask = table.deepcopy(vanilla_rails_mask)

vanilla_rails_mask.layers["space_tile"] = true   -- Here
space_rails_mask.layers.object = nil

for _, rail_prototype in pairs(vanilla_rails) do
  rail_prototype.collision_mask = vanilla_rails_mask
end
```