### PR TITLE
Support renamed turbo tier belts in Bob's Logistics 2.1.0 (fixes #41)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 Version: 0.13.1
 Date: ????
   Changes:
+    - support the renamed turbo tier belts in Bob's Logistics 2.1.0 (fixes #41)
 ---------------------------------------------------------------------------------------------------
 Version: 0.13.0
 Date: 2026-05-06

--- a/prototypes/templates.lua
+++ b/prototypes/templates.lua
@@ -703,11 +703,22 @@ local loaders = {
         data = function(dash_prefix)
             local previous = 'express'
 
+            -- bob's logistics 2.1.0 renamed its turbo tier belts to the space age
+            -- names (bob-turbo-transport-belt -> turbo-transport-belt etc., see the
+            -- boblogistics 2.1.0 migration). Fall back to the new names if the old
+            -- ones no longer exist.
+            local belt_gfx = nil
+            if not data.raw['transport-belt'][dash_prefix .. 'transport-belt'] then
+                dash_prefix = 'turbo-'
+                belt_gfx = 'turbo'
+            end
+
             return {
                 order = 'd[a]-q',
                 subgroup = 'belt',
                 stack_size = 50,
                 tint = util.color('b700ff'),
+                belt_gfx = belt_gfx,
                 speed = data.raw['transport-belt'][dash_prefix .. 'transport-belt'].speed,
                 upgrade_from = const:name_from_prefix(previous),
                 corpse_gfx = '', -- use basic graphics for explosion and remnants


### PR DESCRIPTION
## Problem

Bob's Logistics 2.1.0 renamed its turbo tier belts to the Space Age names (see its `migrations/boblogistics_2.1.0.json`):

- `bob-turbo-transport-belt` → `turbo-transport-belt`
- `bob-turbo-underground-belt` → `turbo-underground-belt`
- `bob-turbo-splitter` → `turbo-splitter`

The `bob-turbo` loader template still looks up the old belt name for its `speed`, which crashes the data stage:

```
miniloader-redux/prototypes/templates.lua:711: attempt to index field '?' (a nil value)
stack traceback:
        miniloader-redux/prototypes/templates.lua:711: in function 'data'
        miniloader-redux/data-updates.lua:52: in main chunk
```

Fixes #41

## Fix

In the `bob-turbo` template, fall back to the `turbo-` prefix when `bob-turbo-transport-belt` no longer exists, and set `belt_gfx = 'turbo'` so the loader belt animation matches. This keeps the loader's own name/prototypes unchanged (`hps__ml-bob-turbo-miniloader`) and stays compatible with older Bob's Logistics versions that still have the `bob-turbo-*` belts.

The ingredient and gfx fallbacks come for free since they use the same `dash_prefix`. `bob-turbo-inserter` / `bob-express-inserter` and `logistics-4` still exist in Bob's 2.1, so the rest of the template is untouched.

## Testing

Verified with Bob's Logistics 2.1.1 in a large Angel's+Bob's modpack via `factorio --dump-data` (Factorio 2.0.76):

- data stage loads cleanly (previously crashed at `templates.lua:711`)
- `hps__ml-bob-turbo-miniloader-l` speed = `0.1875` = `turbo-transport-belt` speed
- recipe ingredients resolve to `turbo-underground-belt`
- `belt_animation_set` matches `turbo-underground-belt` (without `belt_gfx` it silently fell back to default graphics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)