### PR TITLE
Add ultimate belts space age plus

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -14,6 +14,10 @@ local const = require('lib.constants')
 local templates = require('prototypes.templates')
 local functions = require('prototypes.functions')
 
+if mods['UltimateBeltsSpaceAgePlus'] then
+    require('prototypes.compatibility.ultimate-belts-space-age-plus')(templates)
+end
+
 local upgrades = {}
 
 if Framework.settings:startup_setting('debug_mode') then

--- a/info.json
+++ b/info.json
@@ -21,14 +21,14 @@
     "git_publish_branch": "main",
     "readme": "README.md",
     "gallery": [
-      "portal/all-belts.gif",
+	  "portal/all-belts.gif",
       "portal/all-belts-stacked.gif",
-      "portal/lane-filter.gif",
-      "portal/sideloading.gif",
-      "portal/normal-mode-gui.png",
-      "portal/speed-mode-gui.png",
-      "portal/extended_rotation.gif",
-      "portal/picker-dollies.gif"
+	  "portal/lane-filter.gif",
+	  "portal/sideloading.gif",
+	  "portal/normal-mode-gui.png",
+	  "portal/speed-mode-gui.png",
+	  "portal/extended_rotation.gif",
+	  "portal/picker-dollies.gif"
     ],
     "sync_portal_details": true,
     "ignore": [

--- a/info.json
+++ b/info.json
@@ -9,6 +9,7 @@
   "factorio_version": "2.1",
   "dependencies": [
     "base >= 2.1.7",
+    "(?) UltimateBeltsSpaceAgePlus",
     "(?) matts-logistics",
     "(?) Krastorio2 >= 2.0.7",
     "(?) boblogistics >= 2.1.0",
@@ -20,14 +21,14 @@
     "git_publish_branch": "main",
     "readme": "README.md",
     "gallery": [
-	  "portal/all-belts.gif",
+      "portal/all-belts.gif",
       "portal/all-belts-stacked.gif",
-	  "portal/lane-filter.gif",
-	  "portal/sideloading.gif",
-	  "portal/normal-mode-gui.png",
-	  "portal/speed-mode-gui.png",
-	  "portal/extended_rotation.gif",
-	  "portal/picker-dollies.gif"
+      "portal/lane-filter.gif",
+      "portal/sideloading.gif",
+      "portal/normal-mode-gui.png",
+      "portal/speed-mode-gui.png",
+      "portal/extended_rotation.gif",
+      "portal/picker-dollies.gif"
     ],
     "sync_portal_details": true,
     "ignore": [

--- a/locale/en/ultimate-belts-space-age-plus.cfg
+++ b/locale/en/ultimate-belts-space-age-plus.cfg
@@ -1,0 +1,61 @@
+[technology-name]
+hps__ml-ub-ultra-fast-miniloader=Ultra fast miniloader
+hps__ml-ub-ultra-express-miniloader=Ultra express miniloader
+hps__ml-ub-extreme-fast-miniloader=Extreme fast miniloader
+hps__ml-ub-extreme-express-miniloader=Extreme express miniloader
+hps__ml-ub-ultimate-miniloader=Ultimate miniloader
+
+[technology-description]
+hps__ml-ub-ultra-fast-miniloader=An ultra fast miniloader. Can keep up with ultra fast belts.
+hps__ml-ub-ultra-express-miniloader=An ultra express miniloader. Can keep up with ultra express belts.
+hps__ml-ub-extreme-fast-miniloader=An extreme fast miniloader. Can keep up with extreme fast belts.
+hps__ml-ub-extreme-express-miniloader=An extreme express miniloader. Can keep up with extreme express belts.
+hps__ml-ub-ultimate-miniloader=The ultimate miniloader. Can keep up with ultimate belts.
+
+[entity-name]
+hps__ml-ub-ultra-fast-miniloader=Ultra fast miniloader
+hps__ml-ub-ultra-express-miniloader=Ultra express miniloader
+hps__ml-ub-extreme-fast-miniloader=Extreme fast miniloader
+hps__ml-ub-extreme-express-miniloader=Extreme express miniloader
+hps__ml-ub-ultimate-miniloader=Ultimate miniloader
+hps__ml-ub-ultra-fast-miniloader-i=Internal logic for the ultra fast miniloader
+hps__ml-ub-ultra-express-miniloader-i=Internal logic for the ultra express miniloader
+hps__ml-ub-extreme-fast-miniloader-i=Internal logic for the extreme fast miniloader
+hps__ml-ub-extreme-express-miniloader-i=Internal logic for the extreme express miniloader
+hps__ml-ub-ultimate-miniloader-i=Internal logic for the ultimate miniloader
+hps__ml-ub-ultra-fast-miniloader-l=Ultra fast miniloader
+hps__ml-ub-ultra-express-miniloader-l=Ultra express miniloader
+hps__ml-ub-extreme-fast-miniloader-l=Extreme fast miniloader
+hps__ml-ub-extreme-express-miniloader-l=Extreme express miniloader
+hps__ml-ub-ultimate-miniloader-l=Ultimate miniloader
+
+[entity-description]
+hps__ml-ub-ultra-fast-miniloader=An ultra fast miniloader. Can keep up with ultra fast belts.
+hps__ml-ub-ultra-express-miniloader=An ultra express miniloader. Can keep up with ultra express belts.
+hps__ml-ub-extreme-fast-miniloader=An extreme fast miniloader. Can keep up with extreme fast belts.
+hps__ml-ub-extreme-express-miniloader=An extreme express miniloader. Can keep up with extreme express belts.
+hps__ml-ub-ultimate-miniloader=The ultimate miniloader. Can keep up with ultimate belts.
+hps__ml-ub-ultra-fast-miniloader-i=Internal logic and components for the ultra fast miniloader.
+hps__ml-ub-ultra-express-miniloader-i=Internal logic and components for the ultra express miniloader.
+hps__ml-ub-extreme-fast-miniloader-i=Internal logic and components for the extreme fast miniloader.
+hps__ml-ub-extreme-express-miniloader-i=Internal logic and components for the extreme express miniloader.
+hps__ml-ub-ultimate-miniloader-i=Internal logic and components for the ultimate miniloader.
+hps__ml-ub-ultra-fast-miniloader-l=Internal logic and components for the ultra fast miniloader.
+hps__ml-ub-ultra-express-miniloader-l=Internal logic and components for the ultra express miniloader.
+hps__ml-ub-extreme-fast-miniloader-l=Internal logic and components for the extreme fast miniloader.
+hps__ml-ub-extreme-express-miniloader-l=Internal logic and components for the extreme express miniloader.
+hps__ml-ub-ultimate-miniloader-l=Internal logic and components for the ultimate miniloader.
+
+[item-name]
+hps__ml-ub-ultra-fast-miniloader=Ultra fast miniloader
+hps__ml-ub-ultra-express-miniloader=Ultra express miniloader
+hps__ml-ub-extreme-fast-miniloader=Extreme fast miniloader
+hps__ml-ub-extreme-express-miniloader=Extreme express miniloader
+hps__ml-ub-ultimate-miniloader=Ultimate miniloader
+
+[item-description]
+hps__ml-ub-ultra-fast-miniloader=An ultra fast miniloader. Can keep up with ultra fast belts.
+hps__ml-ub-ultra-express-miniloader=An ultra express miniloader. Can keep up with ultra express belts.
+hps__ml-ub-extreme-fast-miniloader=An extreme fast miniloader. Can keep up with extreme fast belts.
+hps__ml-ub-extreme-express-miniloader=An extreme express miniloader. Can keep up with extreme express belts.
+hps__ml-ub-ultimate-miniloader=The ultimate miniloader. Can keep up with ultimate belts.

--- a/prototypes/compatibility/ultimate-belts-space-age-plus.lua
+++ b/prototypes/compatibility/ultimate-belts-space-age-plus.lua
@@ -1,0 +1,155 @@
+------------------------------------------------------------------------
+-- Ultimate Belts Space Age Plus compatibility
+------------------------------------------------------------------------
+
+local util = require('util')
+local const = require('lib.constants')
+
+local STACKING_ENABLED = feature_flags.space_travel
+
+local SPEED_SETTINGS = {
+    speed_90 = {
+        items_per_second = 90,
+        rotation_speed = 0.25,
+        inserter_pairs = 1,
+        stack_size_bonus = 3,
+        power_correction = 897/305,
+    },
+    speed_180 = {
+        items_per_second = 180,
+        rotation_speed = 0.5,
+        inserter_pairs = 2,
+        stack_size_bonus = 2,
+        power_correction = 2070/703,
+    },
+    speed_270 = {
+        items_per_second = 270,
+        rotation_speed = 0.5,
+        inserter_pairs = 3,
+        stack_size_bonus = 2,
+        power_correction = 3350/1130,
+    },
+    speed_360 = {
+        items_per_second = 360,
+        rotation_speed = 0.5,
+        inserter_pairs = 4,
+        stack_size_bonus = 2,
+        power_correction = 4700/1200,
+    },
+    speed_450 = {
+        items_per_second = 450,
+        rotation_speed = 0.5,
+        inserter_pairs = 4,
+        stack_size_bonus = 7,
+        power_correction = 6090/1650,
+    },
+}
+
+local function add_loader(loaders, tier, max_loader)
+    loaders[tier.prefix] = {
+        condition = function()
+            return true
+        end,
+        data = function()
+            return {
+                order = tier.order,
+                subgroup = 'belt',
+                stack_size = 50,
+                tint = util.color(tier.tint),
+                speed = data.raw['transport-belt'][tier.transport_belt].speed,
+                stack = STACKING_ENABLED,
+                upgrade_from = const:name_from_prefix(tier.previous),
+                corpse_gfx = tier.graphics_prefix,
+                explosion_gfx = max_loader,
+                belt_gfx = tier.graphics_prefix,
+                ingredients = function()
+                    return {
+                        { type = 'item', name = const:name_from_prefix(tier.previous), amount = tier.previous_count },
+                        { type = 'item', name = tier.underground_belt, amount = 1 },
+                        { type = 'item', name = 'bulk-inserter', amount = tier.inserter_count },
+                    }
+                end,
+                prerequisites = function()
+                    return { tier.technology, const:name_from_prefix(tier.previous), }
+                end,
+                speed_config = tier.speed_config,
+            }
+        end,
+    }
+end
+
+return function(templates)
+    local max_loader = mods['space-age'] and 'turbo' or 'express'
+
+    local tiers = {
+        {
+            prefix = 'ub-ultra-fast',
+            previous = max_loader,
+            previous_count = 1,
+            inserter_count = 4,
+            order = 'd[b]-f',
+            tint = '00b30cFF',
+            transport_belt = 'ultra-fast-belt',
+            underground_belt = 'ultra-fast-underground-belt',
+            graphics_prefix = 'ultra-fast',
+            technology = 'ultra-fast-logistics',
+            speed_config = SPEED_SETTINGS.speed_90,
+        },
+        {
+            prefix = 'ub-extreme-fast',
+            previous = 'ub-ultra-fast',
+            previous_count = 2,
+            inserter_count = 2,
+            order = 'd[b]-g',
+            tint = 'e00000FF',
+            transport_belt = 'extreme-fast-belt',
+            underground_belt = 'extreme-fast-underground-belt',
+            graphics_prefix = 'extreme-fast',
+            technology = 'extreme-fast-logistics',
+            speed_config = SPEED_SETTINGS.speed_180,
+        },
+        {
+            prefix = 'ub-ultra-express',
+            previous = 'ub-extreme-fast',
+            previous_count = 2,
+            inserter_count = 2,
+            order = 'd[b]-h',
+            tint = '3604b5E8',
+            transport_belt = 'ultra-express-belt',
+            underground_belt = 'ultra-express-underground-belt',
+            graphics_prefix = 'ultra-express',
+            technology = 'ultra-express-logistics',
+            speed_config = SPEED_SETTINGS.speed_270,
+        },
+        {
+            prefix = 'ub-extreme-express',
+            previous = 'ub-ultra-express',
+            previous_count = 2,
+            inserter_count = 2,
+            order = 'd[b]-i',
+            tint = '002bffFF',
+            transport_belt = 'extreme-express-belt',
+            underground_belt = 'extreme-express-underground-belt',
+            graphics_prefix = 'extreme-express',
+            technology = 'extreme-express-logistics',
+            speed_config = SPEED_SETTINGS.speed_360,
+        },
+        {
+            prefix = 'ub-ultimate',
+            previous = 'ub-extreme-express',
+            previous_count = 2,
+            inserter_count = 2,
+            order = 'd[b]-j',
+            tint = '00ffddD1',
+            transport_belt = 'ultimate-belt',
+            underground_belt = 'original-ultimate-underground-belt',
+            graphics_prefix = 'original-ultimate',
+            technology = 'ultimate-logistics',
+            speed_config = SPEED_SETTINGS.speed_450,
+        },
+    }
+
+    for _, tier in ipairs(tiers) do
+        add_loader(templates.loaders, tier, max_loader)
+    end
+end

--- a/prototypes/compatibility/ultimate-belts-space-age-plus.lua
+++ b/prototypes/compatibility/ultimate-belts-space-age-plus.lua
@@ -7,6 +7,9 @@ local const = require('lib.constants')
 
 local STACKING_ENABLED = feature_flags.space_travel
 
+-- Ultimate Belts uses 2x through 6x express-belt speed (90/135/180/225/270 items/s).
+-- The 90, 180 and 270 configurations match existing Miniloader Redux speed tiers.
+-- The 135 and 225 configurations interpolate rotation speed and need in-game throughput validation.
 local SPEED_SETTINGS = {
     speed_90 = {
         items_per_second = 90,
@@ -15,6 +18,13 @@ local SPEED_SETTINGS = {
         stack_size_bonus = 3,
         power_correction = 897/305,
     },
+    speed_135 = {
+        items_per_second = 135,
+        rotation_speed = 0.375,
+        inserter_pairs = 1,
+        stack_size_bonus = 3,
+        power_correction = 1,
+    },
     speed_180 = {
         items_per_second = 180,
         rotation_speed = 0.5,
@@ -22,26 +32,19 @@ local SPEED_SETTINGS = {
         stack_size_bonus = 2,
         power_correction = 2070/703,
     },
+    speed_225 = {
+        items_per_second = 225,
+        rotation_speed = 5/12,
+        inserter_pairs = 3,
+        stack_size_bonus = 2,
+        power_correction = 1,
+    },
     speed_270 = {
         items_per_second = 270,
         rotation_speed = 0.5,
         inserter_pairs = 3,
         stack_size_bonus = 2,
         power_correction = 3350/1130,
-    },
-    speed_360 = {
-        items_per_second = 360,
-        rotation_speed = 0.5,
-        inserter_pairs = 4,
-        stack_size_bonus = 2,
-        power_correction = 4700/1200,
-    },
-    speed_450 = {
-        items_per_second = 450,
-        rotation_speed = 0.5,
-        inserter_pairs = 4,
-        stack_size_bonus = 7,
-        power_correction = 6090/1650,
     },
 }
 
@@ -106,7 +109,7 @@ return function(templates)
             underground_belt = 'extreme-fast-underground-belt',
             graphics_prefix = 'extreme-fast',
             technology = 'extreme-fast-logistics',
-            speed_config = SPEED_SETTINGS.speed_180,
+            speed_config = SPEED_SETTINGS.speed_135,
         },
         {
             prefix = 'ub-ultra-express',
@@ -119,7 +122,7 @@ return function(templates)
             underground_belt = 'ultra-express-underground-belt',
             graphics_prefix = 'ultra-express',
             technology = 'ultra-express-logistics',
-            speed_config = SPEED_SETTINGS.speed_270,
+            speed_config = SPEED_SETTINGS.speed_180,
         },
         {
             prefix = 'ub-extreme-express',
@@ -132,7 +135,7 @@ return function(templates)
             underground_belt = 'extreme-express-underground-belt',
             graphics_prefix = 'extreme-express',
             technology = 'extreme-express-logistics',
-            speed_config = SPEED_SETTINGS.speed_360,
+            speed_config = SPEED_SETTINGS.speed_225,
         },
         {
             prefix = 'ub-ultimate',
@@ -145,7 +148,7 @@ return function(templates)
             underground_belt = 'original-ultimate-underground-belt',
             graphics_prefix = 'original-ultimate',
             technology = 'ultimate-logistics',
-            speed_config = SPEED_SETTINGS.speed_450,
+            speed_config = SPEED_SETTINGS.speed_270,
         },
     }
 


### PR DESCRIPTION
Summary

Adds compatibility for Ultimate Belts Space Age Plus to Miniloader Redux.

The original Miniloader mod supported Ultimate Belts, but that compatibility was lost in Miniloader Redux. This restores matching miniloaders for the five additional belt tiers:

Ultra Fast
Extreme Fast
Ultra Express
Extreme Express
Ultimate
Changes
Adds UltimateBeltsSpaceAgePlus as an optional dependency for correct load order.
Adds loader definitions for all five Ultimate Belts tiers.
Uses the actual belt and underground-belt prototype names from Ultimate Belts Space Age Plus.
Adds matching upgrade chains, technologies, recipes, colors and locale entries.
Uses the corresponding belt speeds for each tier.
Testing

Tested in-game with:

Miniloader Redux 2.1.1
Ultimate Belts Space Age Plus 0.0.8
Factorio 2.1

All five additional miniloaders are created correctly and appear in-game.

This change only adds compatibility when UltimateBeltsSpaceAgePlus is installed and does not affect the existing loader tiers when the mod is absent.